### PR TITLE
Add standalone phar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
 /public/
 /var/
+
+/build/
+!/build/.gitignore

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ These can be copied to the `bin/` directory of your project (if not already pres
 
 ## Standalone
 
-> Note: The phar is a planned feature.
+> Note: The phar is still experimental, and does not support integrated use with shopware projects (yet).
 
 The tool can be used as standalone, phar or source, for example in CI pipelines:
 
@@ -258,6 +258,35 @@ PHP is required. The source archive will need [composer](https://getcomposer.org
 
 Find the source archive and prebuilt phar attached to
  the [latest release](https://github.com/machinateur/twig-block-validator/releases).
+
+### Build the phar
+
+This instruction requires [box](https://github.com/box-project/box) to be installed globally.
+
+```bash
+# navigate to project
+cd twig-block-validator
+
+# set up env
+export APP_ENV=prod
+export APP_DEBUG=0
+
+# prepare cache
+bin/console cache:clear
+rm -rf var/cache/prod
+bin/console cache:warmup
+# check if everything is fine
+bin/box -V
+
+# remove old logs
+rm var/log/*.log || mkdir -p var/log
+
+# compile the phar
+box compile -vvv
+
+# run the phar
+./build/twig-block-validator.phar
+```
 
 ## License
 

--- a/bin/box
+++ b/bin/box
@@ -1,0 +1,30 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Machinateur\TwigBlockValidator\Box\BoxKernel;
+use Machinateur\TwigBlockValidator\Command\TwigBlockAnnotateCommand;
+use Machinateur\TwigBlockValidator\Command\TwigBlockValidateCommand;
+use Machinateur\TwigBlockValidator\TwigBlockValidatorBundle;
+use Symfony\Component\Console\Application;
+
+$_SERVER['APP_RUNTIME_OPTIONS']['disable_dotenv'] = true;
+
+require_once __DIR__ . '/../vendor/autoload_runtime.php';
+
+return static function (array & $context) {
+    \set_time_limit(0);
+
+    $kernel      = new BoxKernel();
+    $kernel->boot();
+
+    $container   = $kernel->getContainer();
+    $application = new Application('Twig Block Validator', TwigBlockValidatorBundle::VERSION);
+    $application->addCommands([
+            $container->get(TwigBlockValidateCommand::class),
+            $container->get(TwigBlockAnnotateCommand::class),
+    ]);
+
+    return $application;
+};

--- a/bin/console
+++ b/bin/console
@@ -3,7 +3,6 @@
 
 declare(strict_types=1);
 
-use Composer\InstalledVersions;
 use Machinateur\TwigBlockValidator\Command\TwigBlockValidateCommand;
 use Machinateur\TwigBlockValidator\Twig\Extension\BlockValidatorExtension;
 use Machinateur\TwigBlockValidator\TwigBlockValidatorBundle;
@@ -39,9 +38,8 @@ return static function (array & $context) {
     // Note: This causes an error when calling with `-t @Namespaced:path/to/the/templates`, as it mistakes the `:` for a command namespace.
     //$application->setDefaultCommand($defaultName = TwigBlockValidateCommand::getDefaultName());
 
-    if (null !== $version = InstalledVersions::getVersion('shopware/storefront')) {
+    if (null !== $version = TwigBlockValidatorKernel::getShopwareVersion()) {
         $application->setName('Twig Block Validator (for Shopware 6)');
-        //$application->setVersion($version);
 
         BlockValidatorExtension::$preferredLabel = 'shopware';
 

--- a/bin/twig-block-annotate
+++ b/bin/twig-block-annotate
@@ -3,7 +3,6 @@
 
 declare(strict_types=1);
 
-use Composer\InstalledVersions;
 use Machinateur\TwigBlockValidator\Command\TwigBlockAnnotateCommand;
 use Machinateur\TwigBlockValidator\Twig\Extension\BlockValidatorExtension;
 use Machinateur\TwigBlockValidator\TwigBlockValidatorBundle;
@@ -29,12 +28,12 @@ return static function (array & $context) {
     $kernel      = new TwigBlockValidatorKernel($env, $debug);
     $defaultName = TwigBlockAnnotateCommand::getDefaultName();
     $application = new Application($kernel);
-    $application->setName('Twig Block Validator');
+    $application->setName('Twig Block Validator : Annotate');
     $application->setVersion(TwigBlockValidatorBundle::VERSION);
 
     $kernel->boot();
 
-    if (null !== $version = InstalledVersions::getVersion('shopware/storefront')) {
+    if (null !== $version = TwigBlockValidatorKernel::getShopwareVersion()) {
         BlockValidatorExtension::$preferredLabel = 'shopware';
 
         $application->get($defaultName)

--- a/bin/twig-block-validate
+++ b/bin/twig-block-validate
@@ -3,7 +3,6 @@
 
 declare(strict_types=1);
 
-use Composer\InstalledVersions;
 use Machinateur\TwigBlockValidator\Command\TwigBlockValidateCommand;
 use Machinateur\TwigBlockValidator\Twig\Extension\BlockValidatorExtension;
 use Machinateur\TwigBlockValidator\TwigBlockValidatorBundle;
@@ -29,12 +28,12 @@ return static function (array & $context) {
     $kernel      = new TwigBlockValidatorKernel($env, $debug);
     $defaultName = TwigBlockValidateCommand::getDefaultName();
     $application = new Application($kernel);
-    $application->setName('Twig Block Validator');
+    $application->setName('Twig Block Validator : Validate');
     $application->setVersion(TwigBlockValidatorBundle::VERSION);
 
     $kernel->boot();
 
-    if (null !== $version = InstalledVersions::getVersion('shopware/storefront')) {
+    if (null !== $version = TwigBlockValidatorKernel::getShopwareVersion()) {
         BlockValidatorExtension::$preferredLabel = 'shopware';
 
         $application->get($defaultName)

--- a/box.json
+++ b/box.json
@@ -1,0 +1,20 @@
+{
+  "main": "bin/box",
+  "directories": [
+    "config", "src", "vendor", "var"
+  ],
+  "finder": [
+    {
+      "name":    "*.php",
+      "exclude": ["Tests/", "tests/"],
+      "in":      "vendor/"
+    },
+    {
+      "name": "*.yaml",
+      "in":   "src/Resources/config"
+    }
+  ],
+  "compression": "BZ2",
+  "output": "build/twig-block-validator.phar",
+  "banner-file": "LICENSE"
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "type": "library",
   "name": "machinateur/twig-block-validator",
+  "version": "0.1.0-beta",
   "description": "A twig implementation/integration of the Shopware 6 IntelliJ plugin's twig template-hash feature.",
   "keywords": ["twig", "extension", "php", "block-tag", "shopware"],
   "homepage": "https://github.com/machinateur/twig-block-hash",
@@ -18,7 +19,8 @@
     "phpunit/phpunit": "^9.5",
     "shopware/administration": "^6.4",
     "shopware/core": "^6.4",
-    "shopware/storefront": "^6.4"
+    "shopware/storefront": "^6.4",
+    "symfony/flex": "^2.5"
   },
   "require": {
     "php": ">=8.2.0",
@@ -52,11 +54,15 @@
   "config": {
     "allow-plugins": {
       "cweagans/composer-patches": true,
+      "symfony/flex": true,
       "symfony/runtime": true
     },
     "sort-packages": true
   },
   "extra": {
     "patches-file": "patches.json"
+  },
+  "suggest": {
+    "humbug/box": "*"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "03df349dee96343aab308fe090467617",
+    "content-hash": "8135d6a0f5e26ffc0b09a808b3c2b889",
     "packages": [
         {
             "name": "brick/math",
@@ -12210,6 +12210,74 @@
                 "wiki": "https://developer.shopware.com"
             },
             "time": "2025-04-08T07:55:07+00:00"
+        },
+        {
+            "name": "symfony/flex",
+            "version": "v2.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/flex.git",
+                "reference": "62d5c38c7af6280d8605b725364680838b475641"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/62d5c38c7af6280d8605b725364680838b475641",
+                "reference": "62d5c38c7af6280d8605b725364680838b475641",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.1",
+                "php": ">=8.0"
+            },
+            "conflict": {
+                "composer/semver": "<1.7.2"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1",
+                "symfony/dotenv": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Flex\\Flex"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Flex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "Composer plugin for Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/flex/issues",
+                "source": "https://github.com/symfony/flex/tree/v2.5.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-10T14:05:03+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/src/Box/BoxKernel.php
+++ b/src/Box/BoxKernel.php
@@ -25,45 +25,21 @@
 
 declare(strict_types=1);
 
-namespace Machinateur\TwigBlockValidator;
+namespace Machinateur\TwigBlockValidator\Box;
 
-use Composer\InstalledVersions;
-use Symfony\Bundle\DebugBundle\DebugBundle;
-use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
-use Symfony\Bundle\MonologBundle\MonologBundle;
-use Symfony\Bundle\TwigBundle\TwigBundle;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\HttpKernel\Kernel;
+use Machinateur\TwigBlockValidator\TwigBlockValidatorKernel;
 
-class TwigBlockValidatorKernel extends Kernel
+class BoxKernel extends TwigBlockValidatorKernel
 {
-    public static function getShopwareVersion(): ?string
+    public function __construct(string $environment = 'prod', bool $debug = false)
     {
-        try {
-            return InstalledVersions::getVersion('shopware/storefront');
-        } catch (\OutOfBoundsException) {
-            return null;
-        }
+        parent::__construct($environment, $debug);
     }
 
-    /**
-     * @return \Generator<\Symfony\Component\HttpKernel\Bundle\Bundle>
-     */
-    public function registerBundles(): iterable
+    // TODO: Load the current project's kernel and use twig.
+
+    public function getProjectDir(): string
     {
-        yield new FrameworkBundle();
-        yield new TwigBundle();
-        // Needed for prettier console output.
-        yield new MonologBundle();
-
-        if (\in_array($this->getEnvironment(), ['dev', 'test'], true)) {
-            yield new DebugBundle();
-        }
-
-        yield new TwigBlockValidatorBundle();
-    }
-
-    public function registerContainerConfiguration(LoaderInterface $loader): void
-    {
+        return __DIR__.'/../..';
     }
 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,6 +1,7 @@
 services:
 
   Machinateur\TwigBlockValidator\Command\TwigBlockValidateCommand:
+    public: true
     arguments:
       - '@Machinateur\TwigBlockValidator\Validator\TwigBlockValidator'
       - '@Machinateur\TwigBlockValidator\TwigBlockValidatorOutput'
@@ -27,6 +28,7 @@ services:
     alias: 'Machinateur\TwigBlockValidator\Twig\BlockValidatorEnvironment'
 
   Machinateur\TwigBlockValidator\Command\TwigBlockAnnotateCommand:
+    public: true
     arguments:
       - '@Machinateur\TwigBlockValidator\Annotator\TwigBlockAnnotator'
       - '@Machinateur\TwigBlockValidator\TwigBlockValidatorOutput'

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,0 +1,204 @@
+{
+    "nyholm/psr7": {
+        "version": "1.8",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.0",
+            "ref": "4a8c0345442dcca1d8a2c65633dcf0285dd5a5a2"
+        },
+        "files": [
+            "config/packages/nyholm_psr7.yaml"
+        ]
+    },
+    "pentatrion/vite-bundle": {
+        "version": "7.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "6.5",
+            "ref": "3a6673f248f8fc1dd364dadfef4c5b381d1efab6"
+        }
+    },
+    "phpunit/phpunit": {
+        "version": "9.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "9.6",
+            "ref": "6a9341aa97d441627f8bd424ae85dc04c944f8b4"
+        },
+        "files": [
+            ".env.test",
+            "phpunit.xml.dist",
+            "tests/bootstrap.php"
+        ]
+    },
+    "symfony/console": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.3",
+            "ref": "1781ff40d8a17d87cf53f8d4cf0c8346ed2bb461"
+        },
+        "files": [
+            "bin/console"
+        ]
+    },
+    "symfony/debug-bundle": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.3",
+            "ref": "5aa8aa48234c8eb6dbdd7b3cd5d791485d2cec4b"
+        },
+        "files": [
+            "config/packages/debug.yaml"
+        ]
+    },
+    "symfony/flex": {
+        "version": "2.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.4",
+            "ref": "52e9754527a15e2b79d9a610f98185a1fe46622a"
+        },
+        "files": [
+            ".env",
+            ".env.dev"
+        ]
+    },
+    "symfony/framework-bundle": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.2",
+            "ref": "87bcf6f7c55201f345d8895deda46d2adbdbaa89"
+        },
+        "files": [
+            "config/packages/cache.yaml",
+            "config/packages/framework.yaml",
+            "config/preload.php",
+            "config/routes/framework.yaml",
+            "config/services.yaml",
+            "public/index.php",
+            "src/Controller/.gitignore",
+            "src/Kernel.php"
+        ]
+    },
+    "symfony/lock": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.2",
+            "ref": "8e937ff2b4735d110af1770f242c1107fdab4c8e"
+        },
+        "files": [
+            "config/packages/lock.yaml"
+        ]
+    },
+    "symfony/mailer": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "4.3",
+            "ref": "09051cfde49476e3c12cd3a0e44289ace1c75a4f"
+        },
+        "files": [
+            "config/packages/mailer.yaml"
+        ]
+    },
+    "symfony/messenger": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.0",
+            "ref": "ba1ac4e919baba5644d31b57a3284d6ba12d52ee"
+        },
+        "files": [
+            "config/packages/messenger.yaml"
+        ]
+    },
+    "symfony/monolog-bundle": {
+        "version": "3.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.7",
+            "ref": "aff23899c4440dd995907613c1dd709b6f59503f"
+        },
+        "files": [
+            "config/packages/monolog.yaml"
+        ]
+    },
+    "symfony/routing": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.0",
+            "ref": "21b72649d5622d8f7da329ffb5afb232a023619d"
+        },
+        "files": [
+            "config/packages/routing.yaml",
+            "config/routes.yaml"
+        ]
+    },
+    "symfony/scheduler": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.2",
+            "ref": "caea3c928ee9e1b21288fd76aef36f16ea355515"
+        },
+        "files": [
+            "src/Schedule.php"
+        ]
+    },
+    "symfony/translation": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.3",
+            "ref": "e28e27f53663cc34f0be2837aba18e3a1bef8e7b"
+        },
+        "files": [
+            "config/packages/translation.yaml",
+            "translations/.gitignore"
+        ]
+    },
+    "symfony/twig-bundle": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.4",
+            "ref": "cab5fd2a13a45c266d45a7d9337e28dee6272877"
+        },
+        "files": [
+            "config/packages/twig.yaml",
+            "templates/base.html.twig"
+        ]
+    },
+    "symfony/validator": {
+        "version": "7.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "7.0",
+            "ref": "8c1c4e28d26a124b0bb273f537ca8ce443472bfd"
+        },
+        "files": [
+            "config/packages/validator.yaml"
+        ]
+    }
+}


### PR DESCRIPTION
The goal here is, to provide a standalone `twig-block-validator.phar` for portability.

For now, this will not support tight integration with a project it is executed in.

That also means that the phar version of the tool will not yet support and integrate shopware specific twig tags or even custom extensions from a project scope itself. These things are planned to be supported in the future though.