### PR TITLE
Fix twig embed handling

### DIFF
--- a/src/Twig/BlockStackParser.php
+++ b/src/Twig/BlockStackParser.php
@@ -36,13 +36,8 @@ use Twig\TokenStream;
 
 class BlockStackParser extends Parser
 {
-    private ?string $currentBlock = null;
-
     public function parse(TokenStream $stream, $test = null, bool $dropNeedle = false): ModuleNode
     {
-        // Restart the metadata here.
-        $this->currentBlock = null;
-
         return parent::parse($stream, $test, $dropNeedle);
     }
 
@@ -53,15 +48,15 @@ class BlockStackParser extends Parser
     {
         parent::pushBlockStack($name);
 
-        $this->currentBlock = $this->peekBlockStack();
+        $currentBlock = $this->peekBlockStack();
 
-        if (null === $this->currentBlock) {
+        if (null === $currentBlock) {
             throw new \UnexpectedValueException('Cannot push block stack without current block!');
         }
 
         $token = $this->getCurrentToken();
         /** @var BodyNode  $body */
-        $body  = $this->getBlock($this->currentBlock);
+        $body  = $this->getBlock($currentBlock);
         /** @var BlockNode $block */
         $block = $body->getNode('0');
         $block->setAttribute('line_no_start', $token->getLine());
@@ -69,7 +64,9 @@ class BlockStackParser extends Parser
 
     public function popBlockStack(): void
     {
-        if (null === $this->currentBlock) {
+        $currentBlock = $this->peekBlockStack();
+
+        if (null === $currentBlock) {
             throw new \UnexpectedValueException('Cannot pop block stack without current block!');
         }
 
@@ -77,12 +74,10 @@ class BlockStackParser extends Parser
 
         $token = $this->getCurrentToken();
         /** @var BodyNode  $body */
-        $body  = $this->getBlock($this->currentBlock);
+        $body  = $this->getBlock($currentBlock);
         /** @var BlockNode $block */
         $block = $body->getNode('0');
         $block->setAttribute('line_no_end', $token->getLine());
-
-        $this->currentBlock = $this->peekBlockStack();
     }
 
     public function getBlock(string $name): Node

--- a/tests/templates/twig-embed.phpt
+++ b/tests/templates/twig-embed.phpt
@@ -1,0 +1,2 @@
+bin/shopware twig:block:validate -r 6.6.0 -c tests/templates
+bin/console  twig:block:validate -r 6.6.0 -c tests/templates

--- a/tests/templates/twig-embed/content.html.twig
+++ b/tests/templates/twig-embed/content.html.twig
@@ -1,0 +1,11 @@
+<div class="top_box">
+    {% block top %}
+        Top box default content
+    {% endblock %}
+</div>
+
+<div class="bottom_box">
+    {% block bottom %}
+        Bottom box default content
+    {% endblock %}
+</div>

--- a/tests/templates/twig-embed/page.html.twig
+++ b/tests/templates/twig-embed/page.html.twig
@@ -1,0 +1,13 @@
+{% extends "twig-embed/template.html.twig" %}
+
+{% block content %}
+    {% embed "twig-embed/content.html.twig" %}
+        {% block top %}
+            Some content for the top box
+        {% endblock %}
+
+        {% block bottom %}
+            Some content for the bottom box
+        {% endblock %}
+    {% endembed %}
+{% endblock %}

--- a/tests/templates/twig-embed/template.html.twig
+++ b/tests/templates/twig-embed/template.html.twig
@@ -1,0 +1,3 @@
+{% block content %}
+    blabla
+{% endblock %}


### PR DESCRIPTION
The block stack previously was tracked incorrectly with `embed` blocks.

See also #6.