### PR TITLE
Fix undetected recursion

### DIFF
--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -160,17 +160,25 @@ class TwigBlockAnnotator implements ResetInterface
      */
     protected function processBlock(array & $block, ?string $defaultVersion, ?array $comment): void
     {
+        $created          = (null === $comment);
+        $block['created'] = $created;
+
         $template       = $block['template'];
         $blockName      = $block['block'];
 
-        if ( ! isset($block['parent_template'])) {
-            // No parent block - nothing to do.
-            return;
-        }
+        //if ( ! isset($block['parent_template'])) {
+        //    // No parent block - nothing to do.
+        //    return;
+        //}
 
         // Enrich the block, i.e. _AnnotatedBlock.
         $block['source_hash']    = $this->blockResolver->getSourceHash($template, $blockName);
         $block['source_version'] = $defaultVersion;
+
+        if (null === $block['source_hash']) {
+            // No parent block was found, skip.
+            return;
+        }
 
         // Get the source contents and full source code of the template.
         $source = $this->twig->getLoader()
@@ -181,9 +189,7 @@ class TwigBlockAnnotator implements ResetInterface
             $this->getPath($template) ?? $source->getPath(),
         );
 
-        $this->annotateBlock($block, $source, $created = (null === $comment));
-
-        $block['created'] = $created;
+        $this->annotateBlock($block, $source, $created);
     }
 
     /**

--- a/src/Service/TwigBlockResolver.php
+++ b/src/Service/TwigBlockResolver.php
@@ -163,6 +163,15 @@ class TwigBlockResolver
         $firstLine = & $sourceCodeLines[0];
         $lastLine  = & $sourceCodeLines[$blockLineCount - 1];
 
+        if ( ! $firstLine) {
+            // TODO: Check why the line ever becomes null with some templates.
+            throw new SyntaxError(\sprintf('The first line is null in "%s:%s" line %d.', $template, $blockName, $blockLinesStart));
+        }
+        if ( ! $lastLine) {
+            // TODO: Check why the line ever becomes null with some templates.
+            throw new SyntaxError(\sprintf('The first line is null in "%s:%s" line %d.', $template, $blockName, $blockLinesEnd));
+        }
+
         $blockTags = $this->twig->getLexerOptions()['tag_block'];
 
         // Define the parameters to use for regex inception.

--- a/src/Service/TwigBlockResolver.php
+++ b/src/Service/TwigBlockResolver.php
@@ -75,7 +75,9 @@ class TwigBlockResolver
      */
     public function resolveParentBlock(string $template, string $blockName): ?array
     {
-        $templates = [];
+        $originalTemplate = $template;
+        $templates        = [];
+
         do {
             $block = $this->resolveBlock($template, $blockName);
 
@@ -98,6 +100,11 @@ class TwigBlockResolver
             $templates[] = $template;
         } while (null !== $block);
 
+        if ($block && ($block['template'] === $originalTemplate) && $block['block'] === $blockName) {
+            // Cannot return the same template as parent, as was given for resolution.
+            return null;
+        }
+
         return $block;
     }
 
@@ -112,11 +119,8 @@ class TwigBlockResolver
     {
         // Resolve the template block in hierarchy.
         //  In case of `sw_extends` this also works fine, because the top-most block is resolved (i.e. `@Storefront`).
-        try {
-            $parentBlock = $this->resolveParentBlock($template, $blockName);
-        } catch (LoaderError) {
-            $parentBlock = null;
-        }
+        $parentBlock = $this->resolveParentBlock($template, $blockName);
+
         if (null === $parentBlock) {
             return null;
         }

--- a/src/Service/TwigBlockResolver.php
+++ b/src/Service/TwigBlockResolver.php
@@ -79,6 +79,7 @@ class TwigBlockResolver
         $templates        = [];
 
         do {
+            // TODO: This logic is flawed, as it will stop resolving the origin-block when an intermediate parent is hit, that does not contain the respecitve block.
             $block = $this->resolveBlock($template, $blockName);
 
             if ( ! isset($block['parent_template'])) {

--- a/src/Service/TwigBlockResolver.php
+++ b/src/Service/TwigBlockResolver.php
@@ -84,13 +84,14 @@ class TwigBlockResolver
             }
 
             if ($template === $block['parent_template']) {
-                // Infinite loop detected.
+                // Infinite loop detected, self-reference.
                 break;
             }
 
             $template    = $block['parent_template'];
 
             if (\in_array($template, $templates, true)) {
+                // Infinite loop detected, alternating through parents.
                 throw new LoaderError(\sprintf('Recursion error resolving "%s" ("%s")', $template, \implode('", "', $templates)));
             }
 


### PR DESCRIPTION
Fixes #9. At least mitigates the issue, by tracking the template's hierarchy.

Before, referencing a `@Storefront` template that didn't exist, but was extended by two different templates in different namespaces, those were returned in alternating fashion. For those cases, a `\Twig\LoaderError` will be thrown and tracked.

The changes also adapt the parent block resolution, so that it can no longer return the input block, which would cause self-referential annotation and validation.