### PR TITLE
Fix indentation mismatch in twig:block:annotate

### DIFF
--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -242,34 +242,23 @@ class TwigBlockAnnotator implements ResetInterface
 
         $comment     = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
         $commentLine = $blockLinesStart - 1;
-        $prevLine    = $sourceCodeLines[$commentLine];
-        if ( ! $created) {
-            // {# comment #}
-            $prevLinePattern = \vsprintf('{%s(.*)%s}sx', $params);
-            if (1 !== \preg_match($prevLinePattern, $prevLine, $prevLineMatch, flags: \PREG_OFFSET_CAPTURE)) {
-                throw new SyntaxError(\sprintf('The prev-line for block "%s" was not found but expected.', $blockName), $commentLine, $sourceContext);
-            }
+        // Move cursor to block's start tag, to match its indentation.
+        $prevLine    = $sourceCodeLines[$blockLinesStart];
 
-            /** @var _MatchWithOffset $prevLineMatch */
-            $commentOffset    = $prevLineMatch[1][1];
-            // No validation of the comment content itself, as we can be sure at this point it is an exiting annotation.
-            $comment          = \substr_replace($prevLine, $comment, $commentOffset, \strlen($prevLineMatch[1][0]));
-        } else {
-            // Move cursor to block's start tag, to match its indentation.
-            $prevLine    = $sourceCodeLines[$blockLinesStart];
+        // Match block's start line, as the previous line might have no indentation.
+        $prevLinePattern  = \vsprintf('{^\s*}sx', $params);
+        if (1 !== \preg_match($prevLinePattern, $prevLine, $prevLineMatch, flags: \PREG_OFFSET_CAPTURE)) {
+            throw new SyntaxError(\sprintf('The prev-line for block "%s" was not found but expected.', $blockName), $commentLine, $sourceContext);
+        }
 
-            // Match block's start line, as the previous line might have no indentation.
-            $prevLinePattern  = \vsprintf('{^\s*}sx', $params);
-            if (1 !== \preg_match($prevLinePattern, $prevLine, $prevLineMatch, flags: \PREG_OFFSET_CAPTURE)) {
-                throw new SyntaxError(\sprintf('The prev-line for block "%s" was not found but expected.', $blockName), $commentLine, $sourceContext);
-            }
+        // The offset should be 0, as the pattern must start at the beginning of the line (string).
+        /** @var _MatchWithOffset $prevLineMatch */
+        \assert(0 === $prevLineMatch[0][1]);
 
-            // The offset should be 0, as the pattern must start at the beginning of the line (string).
-            /** @var _MatchWithOffset $prevLineMatch */
-            \assert(0 === $prevLineMatch[0][1]);
+        // Add indentation and maintain tags (i.e. `{#`, `#}`), but usually, overwritten blocks are at "col=0" in child templates (if not nested).
+        $comment          = $prevLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
 
-            // Add indentation and maintain tags (i.e. `{#`, `#}`), but usually, overwritten blocks are at "col=0" in child templates (if not nested).
-            $comment          = $prevLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
+        if ($created) {
             ++$commentLine;
 
             // Increment offset.

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -170,6 +170,8 @@ class TwigBlockAnnotator implements ResetInterface
         //    return;
         //}
 
+        // TODO: Also track diff to existing comment.
+
         // Enrich the block, i.e. _AnnotatedBlock.
         $block['created']        = $created;
         $block['source_hash']    = $this->blockResolver->getSourceHash($template, $blockName);

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -160,8 +160,7 @@ class TwigBlockAnnotator implements ResetInterface
      */
     protected function processBlock(array & $block, ?string $defaultVersion, ?array $comment): void
     {
-        $created          = (null === $comment);
-        $block['created'] = $created;
+        $created        = (null === $comment);
 
         $template       = $block['template'];
         $blockName      = $block['block'];
@@ -172,6 +171,7 @@ class TwigBlockAnnotator implements ResetInterface
         //}
 
         // Enrich the block, i.e. _AnnotatedBlock.
+        $block['created']        = $created;
         $block['source_hash']    = $this->blockResolver->getSourceHash($template, $blockName);
         $block['source_version'] = $defaultVersion;
 

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -255,16 +255,20 @@ class TwigBlockAnnotator implements ResetInterface
             // No validation of the comment content itself, as we can be sure at this point it is an exiting annotation.
             $comment          = \substr_replace($prevLine, $comment, $commentOffset, \strlen($prevLineMatch[1][0]));
         } else {
-            // TODO: Match block's start line, as the previous line might have no indentation.
+            // Move cursor to block's start tag, to match its indentation.
+            $prevLine    = $sourceCodeLines[$blockLinesStart];
+
+            // Match block's start line, as the previous line might have no indentation.
             $prevLinePattern  = \vsprintf('{^\s*}sx', $params);
             if (1 !== \preg_match($prevLinePattern, $prevLine, $prevLineMatch, flags: \PREG_OFFSET_CAPTURE)) {
                 throw new SyntaxError(\sprintf('The prev-line for block "%s" was not found but expected.', $blockName), $commentLine, $sourceContext);
             }
 
+            // The offset should be 0, as the pattern must start at the beginning of the line (string).
             /** @var _MatchWithOffset $prevLineMatch */
             \assert(0 === $prevLineMatch[0][1]);
 
-            // Add indentation and maintain tags (i.e. `{#`, `#}`), but usually, overwritten blocks are at "col=0" in child templates.
+            // Add indentation and maintain tags (i.e. `{#`, `#}`), but usually, overwritten blocks are at "col=0" in child templates (if not nested).
             $comment          = $prevLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
             ++$commentLine;
 

--- a/src/Event/Annotator/AnnotateBlocksEvent.php
+++ b/src/Event/Annotator/AnnotateBlocksEvent.php
@@ -49,8 +49,8 @@ class AnnotateBlocksEvent implements NotifiableInterface
      * @param array<string, array<string, _Comment>> $comments
      */
     public function __construct(
-        public readonly array  $blocks,
-        public readonly array  $comments,
-        public readonly string $version,
+        public readonly array   $blocks,
+        public readonly array   $comments,
+        public readonly ?string $version,
     ) {}
 }

--- a/src/Service/TwigBlockResolver.php
+++ b/src/Service/TwigBlockResolver.php
@@ -79,7 +79,8 @@ class TwigBlockResolver
         $templates        = [];
 
         do {
-            // TODO: This logic is flawed, as it will stop resolving the origin-block when an intermediate parent is hit, that does not contain the respecitve block.
+            // TODO: This logic is flawed, as it will stop resolving the origin-block when an intermediate parent is hit,
+            //  that does not contain the respective block. To solve this, use `$this->twig->load($template)->unwrap()->getParent()`.
             $block = $this->resolveBlock($template, $blockName);
 
             if ( ! isset($block['parent_template'])) {


### PR DESCRIPTION
When annotating blocks, as of now the previous line is used, which might not match the offset of the block itself.

This PR changes the cursor for the indentation matching to use the same line as the block's start tag, which should cover most cases.