### PR TITLE
Release 0.2.1

### DIFF
--- a/src/Twig/BlockValidatorEnvironment.php
+++ b/src/Twig/BlockValidatorEnvironment.php
@@ -98,7 +98,6 @@ class BlockValidatorEnvironment extends Environment implements ResetInterface
 
         // Add the parser extension, needed for block tracking.
         BlockValidatorExtension::setParser($this);
-        $this->addExtension(new BlockValidatorExtension());
 
         $this->namespacedPathnameBuilder = new NamespacedPathnameBuilder($loader);
     }


### PR DESCRIPTION
Fix duplicate twig extension error, where the extension was already registered during the `initExtensions()` call.