### PR TITLE
Fix: Reset node visitor

### DIFF
--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -245,7 +245,7 @@ class TwigBlockAnnotator implements ResetInterface
 
         $comment     = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
         $commentLine = $blockLinesStart - 1;
-        $prevLine    = $sourceCodeLines[$commentLine];
+        #$prevLine    = $sourceCodeLines[$commentLine];
         // Move cursor to block's start tag, to match its indentation.
         $prevLine    = $sourceCodeLines[$blockLinesStart];
 

--- a/src/Command/TwigBlockAnnotateCommand.php
+++ b/src/Command/TwigBlockAnnotateCommand.php
@@ -74,9 +74,7 @@ class TwigBlockAnnotateCommand extends AbstractConsoleCommand
 
         if ($outputPath = $input->getArgument('output-path')) {
             $this->annotator->setPath($outputPath);
-        }
-
-        if ( ! $this->output->getConsole()
+        } elseif ( ! $this->output->getConsole()
             ->confirm("To annotate the templates in-place can lead to permanent loss of data!\n Continue?" , (bool)$input->getOption('yes'))
         ) {
             return Command::SUCCESS;

--- a/src/Twig/Node/CommentCollectionNode.php
+++ b/src/Twig/Node/CommentCollectionNode.php
@@ -61,6 +61,14 @@ class CommentCollectionNode extends Node implements CommentCollectionInterface, 
 
     public function reset(): void
     {
-        $this->comments = [];
+        // TwigTemplateTrait
+        $this->template       = null;
+        $this->parentTemplate = null;
+        // TwigBlockStackTrait
+        $this->blockStack     = [];
+        $this->lines          = null;
+        $this->blocks         = [];
+        // CommentCollectionTrait
+        $this->comments       = [];
     }
 }

--- a/src/Twig/NodeVisitor/BlockNodeVisitor.php
+++ b/src/Twig/NodeVisitor/BlockNodeVisitor.php
@@ -51,6 +51,8 @@ class BlockNodeVisitor implements NodeVisitorInterface
 
     public function __construct(?CommentCollectionNode $collection = null, private ?string $defaultVersion = null)
     {
+        // No worry for now, that we use the "lax" version here,
+        //  because TwigValidatorEnvironment provides the "strict" version of the collection node.
         $this->collection = $collection ?? new CommentCollectionNode();
     }
 
@@ -150,7 +152,7 @@ class BlockNodeVisitor implements NodeVisitorInterface
     {
         // Here, we rely on the comments from a `module.body` being visited prior to the `module.blocks` node.
         foreach ($this->comments as $index => $comment) {
-            // The comment has to be located exactly oon the line before the block start.
+            // The comment has to be located exactly on the line before the block start.
             if (1 !== $block->getTemplateLine() - $comment->getTemplateLine()) {
                 continue;
             }


### PR DESCRIPTION
Since `0.3.0` annotating was broken, due to missing properties in `BlockNodeVisitor::reset()`.

Also fixes an inconvenient bug where the in-place annotation confirmation came up even with output path specified on the command.