### PR TITLE
Remove output-path from twig:block:annotate

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,10 +231,7 @@ Description:
   Annotate block versions in twig templates
 
 Usage:
-  twig:block:annotate [options] [--] [<output-path>]
-
-Arguments:
-  output-path                      Where to write the annotated templates (optional)
+  twig:block:annotate [options]
 
 Options:
   -t, --template=TEMPLATE          Twig template path to load (multiple values allowed)

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "symfony/event-dispatcher": "^7.2 | ^6.4 | ^5.4",
     "symfony/finder": "^7.2 | ^6.4 | ^5.4",
     "symfony/framework-bundle": "^7.2 | ^6.4 | ^5.4",
+    "symfony/http-kernel": "^7.2 | ^6.4 | ^5.4",
     "symfony/monolog-bundle": "^3.6",
     "symfony/runtime": "^7.2 | ^6.4 | ^5.4",
     "symfony/twig-bundle": "^7.2 | ^6.4 | ^5.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79f0459fd5ae73a44ce5cb617e371fc5",
+    "content-hash": "3f0268addab22957f47ad690b0c0637c",
     "packages": [
         {
             "name": "composer/semver",
@@ -1603,16 +1603,16 @@
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.3.0",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "ac7b8e163e8c83dce3abcc055a502d4486051a9f"
+                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/ac7b8e163e8c83dce3abcc055a502d4486051a9f",
-                "reference": "ac7b8e163e8c83dce3abcc055a502d4486051a9f",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/72c304de37e1a1cec6d5d12b81187ebd4850a17b",
+                "reference": "72c304de37e1a1cec6d5d12b81187ebd4850a17b",
                 "shasum": ""
             },
             "require": {
@@ -1697,7 +1697,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.3.0"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -1709,11 +1709,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-29T07:47:32+00:00"
+            "time": "2025-08-29T08:23:45+00:00"
         },
         {
             "name": "symfony/monolog-bridge",

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -237,12 +237,12 @@ class TwigBlockAnnotator implements ResetInterface
             \preg_quote($commentTags[1], '#'),
         ];
 
-        $comment     = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
+        $comment   = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
         // Move cursor to block's start tag, to match its indentation.
-        $blockLine   = $sourceCodeLines[$blockLinesStart];
+        $blockLine = $sourceCodeLines[$blockLinesStart];
 
         // Match block's start line, as the previous line might have no indentation.
-        $blockLinePattern  = \vsprintf('{^\s*}sx', $params);
+        $blockLinePattern = \vsprintf('{^\s*}sx', $params);
         if (1 !== \preg_match($blockLinePattern, $blockLine, $blockLineMatch, flags: \PREG_OFFSET_CAPTURE)) {
             throw new SyntaxError(\sprintf('The block-line for block "%s" was not found but expected.', $blockName), $blockLinesStart, $sourceContext);
         }
@@ -252,7 +252,7 @@ class TwigBlockAnnotator implements ResetInterface
         \assert(0 === $blockLineMatch[0][1]);
 
         // Add indentation and maintain tags (i.e. `{#`, `#}`), but usually, overwritten blocks are at "col=0" in child templates (if not nested).
-        $comment          = $blockLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
+        $comment    = $blockLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
 
         if ($created) {
             // Increment offset.

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -231,9 +231,10 @@ class TwigBlockAnnotator implements ResetInterface
             \preg_quote($commentTags[1], '#'),
         ];
 
-        $comment   = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
+        $comment     = BlockValidatorExtension::formatComment($sourceHash, $sourceVersion);
+        $commentLine = $blockLinesStart - 1;
         // Move cursor to block's start tag, to match its indentation.
-        $blockLine = $sourceCodeLines[$blockLinesStart];
+        $blockLine   = $sourceCodeLines[$blockLinesStart];
 
         // Match block's start line, as the previous line might have no indentation.
         $blockLinePattern = \vsprintf('{^\s*}sx', $params);
@@ -249,11 +250,13 @@ class TwigBlockAnnotator implements ResetInterface
         $comment    = $blockLineMatch[0][0] . $commentTags[0] . $comment . $commentTags[1];
 
         if ($created) {
+            $commentLine++;
+
             // Increment offset.
             $this->addOffset($sourceName);
         }
 
-        \array_splice($sourceCodeLines, $blockLinesStart, (int) ( ! $created), $comment);
+        \array_splice($sourceCodeLines, $commentLine, (int) ( ! $created), $comment);
 
         // Reduce to source-code again
         $sourceCode = \implode("\n", $sourceCodeLines);

--- a/src/Annotator/TwigBlockAnnotator.php
+++ b/src/Annotator/TwigBlockAnnotator.php
@@ -77,11 +77,6 @@ class TwigBlockAnnotator implements ResetInterface
         return $this->offsets[$template] ?? 0;
     }
 
-    protected function hasOffset(string $template): bool
-    {
-        return 0 === $this->getOffset($template);
-    }
-
     protected function addOffset(string $template, int $offset = 1): void
     {
         // Make sure offset record exists.
@@ -152,7 +147,6 @@ class TwigBlockAnnotator implements ResetInterface
         // Reset the default version.
         $nodeVisitor->setDefaultVersion($defaultVersion);
     }
-
 
     /**
      * @param _Block $block

--- a/src/Command/AbstractConsoleCommand.php
+++ b/src/Command/AbstractConsoleCommand.php
@@ -63,7 +63,11 @@ abstract class AbstractConsoleCommand extends Command
 
     public static function getDefaultName(): ?string
     {
-        return static::DEFAULT_NAME ?? parent::getDefaultName();
+        return static::DEFAULT_NAME ?? (
+            \method_exists(parent::class, 'getDefaultName')
+                ? parent::getDefaultName()
+                : null
+        );
     }
 
     protected function configure(): void

--- a/src/Command/TwigBlockAnnotateCommand.php
+++ b/src/Command/TwigBlockAnnotateCommand.php
@@ -30,7 +30,6 @@ namespace Machinateur\TwigBlockValidator\Command;
 use Machinateur\TwigBlockValidator\Annotator\TwigBlockAnnotator;
 use Machinateur\TwigBlockValidator\TwigBlockValidatorOutput;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -56,7 +55,6 @@ class TwigBlockAnnotateCommand extends AbstractConsoleCommand
         $this
             ->setDescription('Annotate block versions in twig templates')
             //->setHelp()
-            ->addArgument('output-path', InputArgument::OPTIONAL, 'Where to write the annotated templates (optional)')
             ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Silently approve annotating template in-place')
         ;
     }
@@ -72,12 +70,10 @@ class TwigBlockAnnotateCommand extends AbstractConsoleCommand
         $templatePaths = $this->resolveNamespaces($templatePaths);
         $annotatePaths = $this->resolveNamespaces($annotatePaths);
 
-        if ($outputPath = $input->getArgument('output-path')) {
-            $this->annotator->setPath($outputPath);
-        } elseif ( ! $this->output->getConsole()
+        if ( ! $this->output->getConsole()
             ->confirm("To annotate the templates in-place can lead to permanent loss of data!\n Continue?" , (bool)$input->getOption('yes'))
         ) {
-            return Command::SUCCESS;
+            return Command::FAILURE;
         }
 
         // Fallback to platform twig paths, if none are given.
@@ -92,7 +88,6 @@ class TwigBlockAnnotateCommand extends AbstractConsoleCommand
         }
 
         $this->annotator->annotate($annotatePaths, $templatePaths, $version);
-        $this->annotator->setPath(null);
 
         $this->output->reset();
 

--- a/src/Command/TwigBlockValidateCommand.php
+++ b/src/Command/TwigBlockValidateCommand.php
@@ -103,7 +103,7 @@ class TwigBlockValidateCommand extends AbstractConsoleCommand
 
     public function onValidateComments(ValidateCommentsEvent $event): void
     {
-        $event->callback(ValidateCommentsEvent::CALL_STEP, function (array $comment): void {
+        $event->callback(ValidateCommentsEvent::CALL_STEP, function (ValidateCommentsEvent $event, array $comment): void {
             if ($comment['match']['hash'] && $comment['match']['version']) {
                 return;
             }

--- a/src/Event/NotifiableTrait.php
+++ b/src/Event/NotifiableTrait.php
@@ -44,7 +44,7 @@ trait NotifiableTrait
         }
 
         foreach ($this->callbacks[$name] as $callback) {
-            $callback(...$args);
+            $callback($this, ...$args);
         }
     }
 

--- a/src/Event/TwigLoadPathsErrorEvent.php
+++ b/src/Event/TwigLoadPathsErrorEvent.php
@@ -27,12 +27,12 @@ declare(strict_types=1);
 
 namespace Machinateur\TwigBlockValidator\Event;
 
-use Twig\Error\LoaderError;
+use Twig\Error\Error as TwigError;
 
 readonly class TwigLoadPathsErrorEvent
 {
     /**
-     * @param list<LoaderError> $errors
+     * @param list<TwigError> $errors
      */
     public function __construct(
         public array $errors,

--- a/src/Inspector/TwigBlockInspector.php
+++ b/src/Inspector/TwigBlockInspector.php
@@ -83,7 +83,6 @@ class TwigBlockInspector
         $previousDefaultVersion = $nodeVisitor->getDefaultVersion();
         $nodeVisitor->setDefaultVersion($version);
 
-
         /** @var list<TwigError> $errors */
         $errors   = [];
         $comments = $this->twig->loadComments($scopePaths, $errors);
@@ -95,7 +94,11 @@ class TwigBlockInspector
 
             $event->notify(InspectCommentsEvent::CALL_BEGIN);
 
-            /** @var _CommentCollection $comments */
+            /**
+             * @var _CommentCollection $comments
+             *
+             * @noinspection PhpParameterByRefIsNotUsedAsReferenceInspection keep for consistency
+             */
             foreach ($comments as & $comment) {
                 try {
                     $event->notify(InspectCommentsEvent::CALL_STEP, $comment);

--- a/src/Twig/BlockStackParser.php
+++ b/src/Twig/BlockStackParser.php
@@ -36,11 +36,6 @@ use Twig\TokenStream;
 
 class BlockStackParser extends Parser
 {
-    public function parse(TokenStream $stream, $test = null, bool $dropNeedle = false): ModuleNode
-    {
-        return parent::parse($stream, $test, $dropNeedle);
-    }
-
     /**
      * @param string $name
      */

--- a/src/Twig/BlockValidatorEnvironment.php
+++ b/src/Twig/BlockValidatorEnvironment.php
@@ -50,6 +50,7 @@ use Twig\Environment;
 use Twig\Error\Error as TwigError;
 use Twig\Error\LoaderError;
 use Twig\Error\RuntimeError;
+use Twig\Error\SyntaxError;
 use Twig\Extension\CoreExtension;
 use Twig\Lexer;
 use Twig\Loader\FilesystemLoader;
@@ -245,7 +246,7 @@ class BlockValidatorEnvironment extends Environment implements ResetInterface
                 $event = new TwigLoadFilesEvent($namespace, $paths, $finder)
             );
 
-            /** @var list<LoaderError> $errors */
+            /** @var list<TwigError> $errors */
             $errors = [];
 
             $event->notify(TwigLoadFilesEvent::CALL_BEGIN);
@@ -258,7 +259,7 @@ class BlockValidatorEnvironment extends Environment implements ResetInterface
                     $this->load($template);
 
                     $event->notify(TwigLoadFilesEvent::CALL_STEP, $file);
-                } catch (LoaderError $error) {
+                } catch (TwigError $error) {
                     $errors[] = $error;
 
                     continue;

--- a/src/TwigBlockValidatorKernel.php
+++ b/src/TwigBlockValidatorKernel.php
@@ -81,11 +81,6 @@ class TwigBlockValidatorKernel extends Kernel
         }
     }
 
-    protected function build(ContainerBuilder $container): void
-    {
-        parent::build($container);
-    }
-
     /**
      * Create the standard symfony kernel console application.
      */

--- a/src/TwigBlockValidatorOutput.php
+++ b/src/TwigBlockValidatorOutput.php
@@ -245,6 +245,7 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 }
             }
         );
+        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
         $event->callback(ValidateCommentsEvent::CALL_END,
             static fn () => $table?->render()
         );
@@ -292,6 +293,7 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 $table->addRow($row);
             }
         );
+        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
         $event->callback(AnnotateBlocksEvent::CALL_END,
             static fn () => $table?->render()
         );
@@ -328,6 +330,7 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 $table->addRow($row);
             }
         );
+        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
         $event->callback(ValidateCommentsEvent::CALL_END,
             static fn () => $table?->render()
         );

--- a/src/TwigBlockValidatorOutput.php
+++ b/src/TwigBlockValidatorOutput.php
@@ -347,7 +347,7 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
      */
     protected function listingTwigErrors(array $errors): void
     {
-        $newline = "\n  ";
+        $newline = "\n   ";
 
         $this->console?->listing(
             \array_map(static function (TwigError $error) use ($newline): string {

--- a/src/TwigBlockValidatorOutput.php
+++ b/src/TwigBlockValidatorOutput.php
@@ -158,6 +158,7 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
     public function onTwigLoadPathsError(TwigLoadPathsErrorEvent $event): void
     {
         $this->console?->warning('Twig loader errors!');
+
         $this->listingTwigErrors($event->errors);
     }
 
@@ -170,23 +171,23 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
 
         if ($console->isVeryVerbose()) {
             $event->callback(TwigLoadFilesEvent::CALL_BEGIN,
-                static fn () => $console?->note('Loading files:')
+                static fn (TwigLoadFilesEvent $event) => $console?->note('Loading files:')
             );
             $event->callback(TwigLoadFilesEvent::CALL_STEP,
-                static fn (SplFileInfo $file) => $console?->text(\sprintf('  * %s', $file->getRelativePathname()))
+                static fn (TwigLoadFilesEvent $event, SplFileInfo $file) => $console?->text(\sprintf('  * %s', $file->getRelativePathname()))
             );
             $event->callback(TwigLoadFilesEvent::CALL_END,
-                static fn () => $console?->comment('Count: ' . $event->finder->count())
+                static fn (TwigLoadFilesEvent $event) => $console?->comment('Count: ' . $event->finder->count())
             );
         } else {
             $event->callback(TwigLoadFilesEvent::CALL_BEGIN,
-                static fn () => $console?->progressStart($event->finder->count())
+                static fn (TwigLoadFilesEvent $event) => $console?->progressStart($event->finder->count())
             );
             $event->callback(TwigLoadFilesEvent::CALL_STEP,
-                static fn (SplFileInfo $file) => $console?->progressAdvance()
+                static fn (TwigLoadFilesEvent $event, SplFileInfo $file) => $console?->progressAdvance()
             );
             $event->callback(TwigLoadFilesEvent::CALL_END,
-                static fn () => $console?->progressFinish()
+                static fn (TwigLoadFilesEvent $event) => $console?->progressFinish()
             );
         }
     }
@@ -208,10 +209,10 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
         $table          = $this->console?->createTable();
 
         $event->callback(ValidateCommentsEvent::CALL_BEGIN,
-            static fn () => $table?->setHeaders(['template', 'parent template', 'block', 'hash', 'version', 'mismatch'])
+            static fn (ValidateCommentsEvent $event) => $table?->setHeaders(['template', 'parent template', 'block', 'hash', 'version', 'mismatch'])
         );
         $event->callback(ValidateCommentsEvent::CALL_STEP,
-            static function (array $comment) use ($console, $table, $defaultVersion) {
+            static function (ValidateCommentsEvent $event, array $comment) use ($console, $table, $defaultVersion) {
                 if (null === $table) {
                     return;
                 }
@@ -245,9 +246,11 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 }
             }
         );
-        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
         $event->callback(ValidateCommentsEvent::CALL_END,
-            static fn () => $table?->render()
+            static function (ValidateCommentsEvent $event) use ($table): void {
+                // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
+                $table?->render();
+            }
         );
     }
 
@@ -267,10 +270,10 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
         $table          = $this->console?->createTable();
 
         $event->callback(AnnotateBlocksEvent::CALL_BEGIN,
-            static fn () => $table?->setHeaders(['template', 'parent template', 'block', 'hash', 'version', 'created'])
+            static fn (AnnotateBlocksEvent $event) => $table?->setHeaders(['template', 'parent template', 'block', 'hash', 'version', 'created'])
         );
         $event->callback(AnnotateBlocksEvent::CALL_STEP,
-            static function (array $block, ?array $comment) use ($console, $table, $defaultVersion) {
+            static function (AnnotateBlocksEvent $event, array $block, ?array $comment) use ($console, $table, $defaultVersion) {
                 if (null === $table) {
                     return;
                 }
@@ -293,9 +296,11 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 $table->addRow($row);
             }
         );
-        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
         $event->callback(AnnotateBlocksEvent::CALL_END,
-            static fn () => $table?->render()
+            static function (AnnotateBlocksEvent $event) use ($table): void {
+                // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
+                $table?->render();
+            }
         );
     }
 
@@ -312,11 +317,11 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
     {
         $table          = $this->console?->createTable();
 
-        $event->callback(ValidateCommentsEvent::CALL_BEGIN,
-            static fn () => $table?->setHeaders(['template', 'parent template', 'block', 'block lines', 'comment'])
+        $event->callback(InspectCommentsEvent::CALL_BEGIN,
+            static fn (InspectCommentsEvent $event) => $table?->setHeaders(['template', 'parent template', 'block', 'block lines', 'comment'])
         );
-        $event->callback(ValidateCommentsEvent::CALL_STEP,
-            static function (array $comment) use ($table) {
+        $event->callback(InspectCommentsEvent::CALL_STEP,
+            static function (InspectCommentsEvent $event, array $comment) use ($table) {
                 if (null === $table) {
                     return;
                 }
@@ -330,9 +335,11 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
                 $table->addRow($row);
             }
         );
-        // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
-        $event->callback(ValidateCommentsEvent::CALL_END,
-            static fn () => $table?->render()
+        $event->callback(InspectCommentsEvent::CALL_END,
+            static function (InspectCommentsEvent $event) use ($table): void {
+                // TODO: Add better output (possibly only with verbose / `-vv`) that counts the number of blocks/comments shown.
+                $table?->render();
+            }
         );
     }
 

--- a/src/TwigBlockValidatorOutput.php
+++ b/src/TwigBlockValidatorOutput.php
@@ -347,9 +347,27 @@ class TwigBlockValidatorOutput implements EventSubscriberInterface, ResetInterfa
      */
     protected function listingTwigErrors(array $errors): void
     {
+        $newline = "\n  ";
+
         $this->console?->listing(
-            \array_map(static fn (TwigError $error) => $error->getMessage()
-                . (($prev = $error->getPrevious()) instanceof \Throwable ? "\n  " . $prev->getMessage() : ''), $errors)
+            \array_map(static function (TwigError $error) use ($newline): string {
+                $source = $error->getSourceContext();
+
+                $message = '';
+                if (null !== $source) {
+                    $message      .= 'Path:    ' . $source->getPath()
+                        . $newline . 'Line:    ' . $source->getName() . ':' . $error->getTemplateLine()
+                        . $newline;
+                }
+
+                $message .= 'Message: ' . $error->getMessage();
+
+                if (($prev = $error->getPrevious()) instanceof \Throwable) {
+                    $message .= $newline . $prev->getMessage();
+                }
+
+                return $message;
+            }, $errors)
         );
     }
 

--- a/tests/shopware/init.sh
+++ b/tests/shopware/init.sh
@@ -28,4 +28,4 @@ docker compose up -d
 docker compose exec shop bash -c 'sudo composer self-update'
 docker compose exec shop bash -c 'composer update --lock'
 docker compose exec shop bash -c 'composer install'
-docker compose exec shop bash -c "composer require machinateur/twig-block-validator:dev-$(git branch --show-current)"
+docker compose exec shop bash -c "composer require --dev machinateur/twig-block-validator:dev-$(git branch --show-current)"

--- a/tests/shopware/init.sh
+++ b/tests/shopware/init.sh
@@ -29,3 +29,9 @@ docker compose exec shop bash -c 'sudo composer self-update'
 docker compose exec shop bash -c 'composer update --lock'
 docker compose exec shop bash -c 'composer install'
 docker compose exec shop bash -c "composer require --dev machinateur/twig-block-validator:dev-$(git branch --show-current)"
+
+# Useful commands:
+#docker compose exec shop bash -c 'composer reinstall shopware/storefront'
+#docker compose exec shop bash -c 'bin/console twig:block:inspect -c @Storefront:vendor/shopware/storefront/Resources/views/storefront/ -r'
+#docker compose exec shop bash -c 'bin/console twig:block:validate -c @Storefront:vendor/shopware/storefront/Resources/views/storefront/ -r'
+#docker compose exec shop bash -c 'bin/console twig:block:annotate -c @Storefront:vendor/shopware/storefront/Resources/views/storefront/ -r'


### PR DESCRIPTION
Closes #41 by eliminating the source of the error - the external path. The command now only supports in-place annotation. Breaking change.